### PR TITLE
Added Mapbox Geocoding to the organizations

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1,12 +1,57 @@
 "use client"
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import mapboxgl from "mapbox-gl";
 
 mapboxgl.accessToken = process.env.NEXT_PUBLIC_MAPBOX_TOKEN!;
 
+const restaurantColor = "#1e453e";
+const cboColor = "#00D100";
+
+async function geocodeAddress(address: string): Promise<[number, number] | null> {
+  try {
+    const enriched = `${address}, New York, NY`;
+    const res = await fetch(
+      `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(enriched)}.json?access_token=${mapboxgl.accessToken}`
+    );
+
+    if (!res.ok) {
+      return null;
+    }
+    
+    const data = await res.json();
+    
+    if (!data.features || data.features.length === 0) {
+      return null;
+    }
+    
+    return data.features[0].center || null; 
+  } catch (error) {
+    return null; 
+  }
+}
+
 export default function Map() {
   const mapContainer = useRef<HTMLDivElement>(null);
   const map = useRef<mapboxgl.Map | null>(null);
+  const [organizations, setOrganizations] = useState<Array<any>>([]);;
+  const [mapReady, setMapReady] = useState<boolean>(false);
+
+  useEffect(() => {
+    async function fetchOrganizations() {
+      try {
+        const response = await fetch("/api/organizations");
+        const data = await response.json();
+                
+        if (data.success) {
+          setOrganizations(data.organizations);
+        }
+      } catch (error) {
+        console.error("Error fetching organizations:", error);
+      }
+    }
+
+    fetchOrganizations();
+  }, []);
 
   useEffect(() => {
     if (map.current) return;
@@ -18,11 +63,34 @@ export default function Map() {
       zoom: 14,
     });
 
+    map.current.on("load", () => {
+      setMapReady(true);
+    });
+
     new mapboxgl.Marker({ color: "#e63946" })
       .setLngLat([-73.9836, 40.7469])
       .setPopup(new mapboxgl.Popup().setHTML("<b>Rethink Food HQ</b><br>136 Madison Ave"))
       .addTo(map.current);
   }, []);
+
+  useEffect(() => {
+    if (!mapReady || !map.current || organizations.length === 0) return;
+
+    async function addMarkers() {
+      for (const org of organizations) {
+        const coords = await geocodeAddress(org.street_address);
+        if (coords) {
+          const markerColor = org.org_type === "restaurant" ? restaurantColor : cboColor;
+          new mapboxgl.Marker({ color: markerColor })
+            .setLngLat(coords)
+            .setPopup(new mapboxgl.Popup().setHTML(`<b>${org.name}</b><br>${org.street_address}`))
+            .addTo(map.current!);
+        }
+      }
+    }
+
+    addMarkers();
+  }, [organizations, mapReady]);
 
   return <div ref={mapContainer} className="w-full h-[500px]" />;
 }


### PR DESCRIPTION
## Summary
Updated the Map component to fetch organizations from the backend API and display them dynamically with color-coded markers based on organization type.

## Changes Made

### 1. **Fetched Organization Data from API**
- Added `useEffect` hook to fetch organizations from `/api/organizations` endpoint
- Stored fetched data in component state
- Added error handling for failed API requests

### 2. **Implemented Mapbox Geocoding**
- Created `geocodeAddress()` utility function to convert street addresses to coordinates
- Uses Mapbox Geocoding API: `https://api.mapbox.com/geocoding/v5/mapbox.places/`
- Enriches addresses with "New York, NY" for better geocoding accuracy
- Returns `[longitude, latitude]` tuple or `null` if geocoding fails
- Includes error handling for failed geocoding requests

### 3. **Dynamic Marker Rendering**
- Added third `useEffect` hook that runs when organizations data and map are ready
- Geocodes each organization's `street_address`
- Creates markers at geocoded coordinates
- Adds popup with organization name and address

### 4. **Color-Coded Markers by Type**
- **Restaurants**: `#1e453e` (dark green)
- **CBOs**: `#00D100` (bright green)
- Marker color dynamically set based on `org_type` field

### 5. **Map Ready State Management**
- Added `mapReady` state to ensure markers are only added after map fully loads
- Prevents race condition where markers would be added before map initialization

## ✅ Acceptance Criteria Met

- [x] Map fetches organization data from the API
- [x] Each organization's address is geocoded to lat/lng using Mapbox
- [x] Markers display correctly at their real-world locations
- [x] Restaurants and CBOs are visually distinct via color
- [x] No other map logic or UI is changed (preserved zoom, center, style, HQ marker)

## 🧪 Testing
<img width="314" height="282" alt="Screenshot 2025-10-17 at 4 16 36 PM" src="https://github.com/user-attachments/assets/e675bf32-1f9d-4c4e-944f-ee205f6b176a" />
Correct address
<img width="758" height="399" alt="Screenshot 2025-10-17 at 4 16 21 PM" src="https://github.com/user-attachments/assets/8497935d-e860-4b02-b6b4-adcfea2f76ef" />
Populated markdowns

## Files Changed
- `src/components/Map.tsx` - Complete rewrite to support dynamic data